### PR TITLE
Restarts the LoginActivity if user denies access

### DIFF
--- a/app/src/main/java/com/gmail/jorgegilcavazos/androidjrawsample/LoginActivity.java
+++ b/app/src/main/java/com/gmail/jorgegilcavazos/androidjrawsample/LoginActivity.java
@@ -7,6 +7,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.widget.Toast;
 
 import net.dean.jraw.auth.AuthenticationManager;
 import net.dean.jraw.http.oauth.Credentials;
@@ -42,6 +43,13 @@ public class LoginActivity extends AppCompatActivity {
                     webView.stopLoading();
                     setResult(RESULT_OK, new Intent().putExtra("RESULT_URL", url));
                     finish();
+                } else if (url.contains("error=")) {
+                    Toast.makeText(
+                            LoginActivity.this,
+                            getString(R.string.login_access_denied_error),
+                            Toast.LENGTH_LONG
+                    ).show();
+                    webView.loadUrl(getAuthorizationUrl().toExternalForm());
                 }
             }
         });

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,10 @@
 <resources>
     <string name="app_name">AndroidJrawSample</string>
+
+    <!-- LoginActivity Strings -->
+    <string name="login_access_denied_error">
+        You must click on \"allow\" to complete the sign-in process.
+        The app cannot function correctly without the requested permissions.
+    </string>
+
 </resources>


### PR DESCRIPTION
Checking if the redirect url returns an "error" and restarting the LoginActivity instead of crashing. This happens when the user enter's the correct credentials but "denies" access post-login.